### PR TITLE
Update `is_ingame` for accurate game status

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -658,6 +658,8 @@ impl Bot {
                             let mut world = self.world.write().unwrap();
                             let mut position = self.position.lock().unwrap();
                             let mut temp = self.temporary_data.write().unwrap();
+                            let mut state = self.state.lock().unwrap();
+                            state.is_ingame = false;
                             self.players.lock().unwrap().clear();
                             world.reset();
                             position.reset();

--- a/src/core/variant_handler.rs
+++ b/src/core/variant_handler.rs
@@ -81,6 +81,7 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
                     );
                     let mut state = bot_clone.state.lock().unwrap();
                     state.is_redirecting = false;
+                    state.is_ingame = true;
                 });
             } else {
                 bot.send_packet(
@@ -89,6 +90,7 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
                 );
                 let mut state = bot.state.lock().unwrap();
                 state.is_redirecting = false;
+                state.is_ingame = true;
             }
         }
         "OnCountryState" => {}
@@ -224,7 +226,6 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
             if data.contains_key("type") {
                 if data.get("type").unwrap() == "local" {
                     let mut state = bot.state.lock().unwrap();
-                    state.is_ingame = true;
                     state.net_id = data.get("netID").unwrap().parse().unwrap();
 
                     bot.send_packet(


### PR DESCRIPTION
I found a logic error in the bot state while testing the Lua API. I was trying to find a way to warp to a world if the bot was in the game but not in a world (which sometimes happens). However, I couldn't reliably determine whether the bot was in the game or not. Upon inspecting the code, I noticed that the `is_ingame` state was being set with the `OnSpawn` variant, but it wasn't accurate.

With the current changes, the `is_ingame` state is updated to `true` with the `OnSuperMain` variant and set to `false` when the peer is disconnected. This fix ensures you can now easily track whether the bot is in the game or not.

![2024-11-27_07-31](https://github.com/user-attachments/assets/925ee9cf-215b-4ed9-a53b-a7a4b1daee8f)
