### PR TITLE
fix: legacy login (invalid_credentials) + missing `is_ingame` update

### DIFF
--- a/src/core/variant_handler.rs
+++ b/src/core/variant_handler.rs
@@ -52,6 +52,9 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
                                 EPacketType::NetMessageGenericText,
                                 "action|enter_game\n".to_string(),
                             );
+                            let mut state = bot.state.lock().unwrap();
+                            state.is_redirecting = false;
+                            state.is_ingame = true;
                             return;
                         }
                     }


### PR DESCRIPTION
When a legacy login request is sent with an incorrect password, a `302 Redirect` response is returned. However, since `ureq` does not handle redirects properly (which I encountered issues with), the program gets stuck. To address this, if the response code is not `200`, we can return an `invalid_credentials` error or a more generic error like `something_went_wrong`. I have implemented an update to return `invalid_credentials` when the response status is not `200`. Other alternatives can be explored, but I chose this update as it seems sufficient for now.

Additionally, we can check if `info.token` is empty in `bot.rs#connect_to_server`, as this can lead to unnecessary connection attempts. Sending empty tokens can potentially result in issues like shadow bans. Here's an example of how this check could be implemented:

```rust
fn connect_to_server(&self, ip: &str, port: &str) {
    let info = self.info.lock().unwrap();
    if info.token.is_empty() {
        self.log_error("Token is empty, blocking connection");
        return;
    }
// other logic
}
```