### PR TITLE
feat: `is_allowed_to_warp`

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -660,6 +660,7 @@ impl Bot {
                             let mut temp = self.temporary_data.write().unwrap();
                             let mut state = self.state.lock().unwrap();
                             state.is_ingame = false;
+                            state.is_not_allowed_to_warp = false;
                             self.players.lock().unwrap().clear();
                             world.reset();
                             position.reset();
@@ -863,6 +864,7 @@ impl Bot {
             return;
         }
         self.log_info(&format!("Warping to world: {}", world_name));
+        self.state.lock().unwrap().is_not_allowed_to_warp = true;
         self.send_packet(
             EPacketType::NetMessageGameMessage,
             format!("action|join_request\nname|{}\ninvitedWorld|0\n", world_name),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -660,7 +660,7 @@ impl Bot {
                             let mut temp = self.temporary_data.write().unwrap();
                             let mut state = self.state.lock().unwrap();
                             state.is_ingame = false;
-                            state.is_not_allowed_to_warp = false;
+                            state.is_allowed_to_warp = false;
                             self.players.lock().unwrap().clear();
                             world.reset();
                             position.reset();
@@ -859,12 +859,12 @@ impl Bot {
             .state
             .lock()
             .expect("Failed to lock state")
-            .is_not_allowed_to_warp
+            .is_allowed_to_warp
         {
             return;
         }
         self.log_info(&format!("Warping to world: {}", world_name));
-        self.state.lock().unwrap().is_not_allowed_to_warp = true;
+        self.state.lock().unwrap().is_allowed_to_warp = false;
         self.send_packet(
             EPacketType::NetMessageGameMessage,
             format!("action|join_request\nname|{}\ninvitedWorld|0\n", world_name),

--- a/src/core/variant_handler.rs
+++ b/src/core/variant_handler.rs
@@ -232,7 +232,7 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
                 if data.get("type").unwrap() == "local" {
                     let mut state = bot.state.lock().unwrap();
                     state.net_id = data.get("netID").unwrap().parse().unwrap();
-                    state.is_not_allowed_to_warp = false;
+                    state.is_allowed_to_warp = true;
                     bot.send_packet(
                         EPacketType::NetMessageGenericText,
                         "action|getDRAnimations\n".to_string(),
@@ -317,7 +317,7 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
             bot.players.lock().unwrap().clear();
         }
         "OnFailedToEnterWorld" => {
-            bot.state.lock().unwrap().is_not_allowed_to_warp = false;
+            bot.state.lock().unwrap().is_allowed_to_warp = true;
         }
         _ => {}
     }

--- a/src/core/variant_handler.rs
+++ b/src/core/variant_handler.rs
@@ -57,6 +57,7 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
                             let mut state = bot.state.lock().unwrap();
                             state.is_redirecting = false;
                             state.is_ingame = true;
+                            state.is_allowed_to_warp = true;
                             return;
                         }
                     }
@@ -87,6 +88,7 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
                     let mut state = bot_clone.state.lock().unwrap();
                     state.is_redirecting = false;
                     state.is_ingame = true;
+                    state.is_allowed_to_warp = true;
                 });
             } else {
                 bot.send_packet(
@@ -96,6 +98,7 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
                 let mut state = bot.state.lock().unwrap();
                 state.is_redirecting = false;
                 state.is_ingame = true;
+                state.is_allowed_to_warp = true;
             }
         }
         "OnCountryState" => {}

--- a/src/core/variant_handler.rs
+++ b/src/core/variant_handler.rs
@@ -232,7 +232,7 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
                 if data.get("type").unwrap() == "local" {
                     let mut state = bot.state.lock().unwrap();
                     state.net_id = data.get("netID").unwrap().parse().unwrap();
-
+                    state.is_not_allowed_to_warp = false;
                     bot.send_packet(
                         EPacketType::NetMessageGenericText,
                         "action|getDRAnimations\n".to_string(),
@@ -315,6 +315,9 @@ pub fn handle(bot: Arc<Bot>, _: &TankPacket, data: &[u8]) {
         "OnRequestWorldSelectMenu" => {
             bot.world.write().unwrap().reset();
             bot.players.lock().unwrap().clear();
+        }
+        "OnFailedToEnterWorld" => {
+            bot.state.lock().unwrap().is_not_allowed_to_warp = false;
         }
         _ => {}
     }

--- a/src/types/bot_info.rs
+++ b/src/types/bot_info.rs
@@ -34,7 +34,7 @@ pub struct State {
     pub is_running: bool,
     pub is_redirecting: bool,
     pub is_ingame: bool,
-    pub is_not_allowed_to_warp: bool,
+    pub is_allowed_to_warp: bool,
     pub is_banned: bool,
     pub is_tutorial: bool,
 }


### PR DESCRIPTION
This is the initial implementation of `is_allowed_to_warp`.

- Renamed `is_not_allowed_to_warp` to `is_allowed_to_warp` to reduce logical complexity.  
- Set `is_allowed_to_warp` to `false` when `warp()` is called or when the client disconnects.  
- Set it to `true` when the client receives `OnSpawn`, `OnSuperMainStart..`, or `OnFailedToEnterWorld`.  

Feedback is welcome!